### PR TITLE
XMLParser was moved to the FoundationXML module (fix: #5)

### DIFF
--- a/Sources/XMLJsonCore/XMLParser/XMLParser.swift
+++ b/Sources/XMLJsonCore/XMLParser/XMLParser.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+#if canImport(FoundationXML)
+import FoundationXML
+#endif
 
 
 class Parser: NSObject, XMLParserDelegate {


### PR DESCRIPTION
starting in Swift 5.1